### PR TITLE
heartbeat: Pin wildcard dependency versions (clsx, tailwind-merge)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
     "class-variance-authority": "^0.7.1",
-    "clsx": "*",
+    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "embla-carousel-react": "^8.6.0",
     "graphql": "^16.11.0",
@@ -55,7 +55,7 @@
     "recharts": "^2.15.2",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.3",
-    "tailwind-merge": "*",
+    "tailwind-merge": "^3.0.2",
     "vaul": "^1.1.2",
     "yet-another-react-lightbox": "^3.25.0"
   },


### PR DESCRIPTION
## Heartbeat Auto-Implementation

**What:** Replace "*" versions for clsx and tailwind-merge with specific semver ranges (e.g. ^2.1.1 and ^3.0.2)
**Why:** Wildcard versions can pull breaking changes on any install, causing non-reproducible builds and potential runtime failures
**Files:** frontend/package.json

---
*Automatically discovered and implemented by Heartbeat on 2026-04-04.*
*Review and merge at your convenience.*

Closes #16