### PR TITLE
Remove console.log leaks in apollo-client fetchWithAuth

### DIFF
--- a/frontend/src/lib/apollo-client.ts
+++ b/frontend/src/lib/apollo-client.ts
@@ -27,8 +27,6 @@ export const fetchWithAuth = async (query: string | DocumentNode, variables?: Re
   }
   
   const token = localStorage.getItem('crooked-finger-token');
-  console.log('🔐 Auth token present:', !!token);
-  
   // Convert DocumentNode to string if needed
   const queryString = typeof query === 'string' ? query : (query as DocumentNode).loc?.source.body || '';
   
@@ -42,6 +40,5 @@ export const fetchWithAuth = async (query: string | DocumentNode, variables?: Re
   });
   
   const result = await response.json();
-  console.log('📥 GraphQL response:', result);
   return result;
 };


### PR DESCRIPTION
## Summary
- Remove `console.log` on line 30 that logged auth token presence to browser console
- Remove `console.log` on line 45 that logged full GraphQL response payloads to browser console

These statements leaked sensitive auth status and API response data to any user opening DevTools in production.

Closes #5

## Test plan
- [ ] Verify `fetchWithAuth` still works correctly (auth headers sent, responses returned)
- [ ] Confirm no console.log output in browser DevTools during GraphQL requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)