### PR TITLE
heartbeat: Replace print() with structured logging in backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,9 @@ from app.database.connection import create_tables, get_db
 from app.database.models import User
 from app.utils.auth import get_current_user_from_token, is_user_admin
 from app.core.config import settings
+import logging
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="Crooked Finger Crochet Assistant API",
@@ -19,10 +22,10 @@ app = FastAPI(
 @app.on_event("startup")
 async def startup_event():
     create_tables()
-    print("✅ Database tables created")
-    print(f"🚀 Crooked Finger API starting on port 8001")
-    print(f"🔧 Environment: {settings.environment}")
-    print(f"🎯 GraphQL endpoint: /crooked-finger/graphql")
+    logger.info("Database tables created")
+    logger.info("Crooked Finger API starting on port 8001")
+    logger.info("Environment: %s", settings.environment)
+    logger.info("GraphQL endpoint: /crooked-finger/graphql")
 
 # CORS middleware
 cors_origins = settings.cors_origins.split(",")
@@ -50,7 +53,7 @@ async def get_context(request: Request):
                 # Add user to context for GraphQL resolvers
                 context["user"] = user
         except Exception as e:
-            print(f"Auth error: {e}")  # Debug logging
+            logger.debug("Auth error: %s", e)
             pass  # Invalid token, continue without user
         finally:
             db.close()

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -11,6 +11,9 @@ from app.database.connection import SessionLocal
 import httpx
 import json
 import base64
+import logging
+
+logger = logging.getLogger(__name__)
 
 class GeminiModel(Enum):
     """Available Gemini models with their daily limits and characteristics"""
@@ -94,7 +97,7 @@ class AIService:
                     self.use_openrouter_default = False
         except Exception as e:
             # Table may not exist yet (before migration runs)
-            print(f"Could not load AI config from database (table may not exist yet): {e}")
+            logger.warning("Could not load AI config from database (table may not exist yet): %s", e)
             pass
         finally:
             db.close()
@@ -125,7 +128,7 @@ class AIService:
                 # Use direct API key parameter (proven to work)
                 self.client = genai.Client(api_key=self.gemini_api_key)
             except Exception as e:
-                print(f"Failed to create Gemini client with direct API key: {e}")
+                logger.error("Failed to create Gemini client with direct API key: %s", e)
                 return None
         return self.client
 
@@ -375,7 +378,7 @@ class AIService:
             return "image/webp"
         else:
             # Default to JPEG if unknown (most common for photos)
-            print(f"Warning: Unknown file type, defaulting to image/jpeg. First bytes: {data[:10].hex()}")
+            logger.warning("Unknown file type, defaulting to image/jpeg. First bytes: %s", data[:10].hex())
             return "image/jpeg"
 
     async def _translate_with_gemini(self, pattern_text: str, context: str, complexity: str = "complex") -> str:
@@ -526,7 +529,7 @@ Always be encouraging and provide practical, actionable advice."""
                         ))
                     contents = parts
                 except (json.JSONDecodeError, base64.binascii.Error) as e:
-                    print(f"Warning: Failed to parse image data: {e}")
+                    logger.warning("Failed to parse image data: %s", e)
                     contents = combined_prompt
             else:
                 contents = combined_prompt
@@ -610,7 +613,7 @@ Provide detailed, beginner-friendly instructions."""
 
             except Exception as e:
                 last_error = e
-                print(f"OpenRouter model {model_name} failed: {e}, trying next model...")
+                logger.warning("OpenRouter model %s failed: %s, trying next model...", model_name, e)
                 continue
 
         # All models failed
@@ -620,7 +623,7 @@ Provide detailed, beginner-friendly instructions."""
         """Use OpenRouter models for crochet/knitting chat with fallback (image support not yet implemented)"""
         # TODO: Add image support for OpenRouter models that support it
         if image_data:
-            print("Warning: Image data provided but OpenRouter image support not yet implemented")
+            logger.warning("Image data provided but OpenRouter image support not yet implemented")
         # Use RAG to analyze user request and enhance context
         user_analysis = rag_service.analyze_user_request(message)
 
@@ -691,7 +694,7 @@ Always be encouraging and provide practical, actionable advice."""
 
             except Exception as e:
                 last_error = e
-                print(f"OpenRouter model {model_name} failed: {e}, trying next model...")
+                logger.warning("OpenRouter model %s failed: %s, trying next model...", model_name, e)
                 continue
 
         # All models failed
@@ -814,7 +817,7 @@ Provide a clear, step-by-step translation."""
         """Chat using a specific OpenRouter model (image support not yet implemented)"""
         # TODO: Add image support for OpenRouter models that support it
         if image_data:
-            print("Warning: Image data provided but OpenRouter image support not yet implemented")
+            logger.warning("Image data provided but OpenRouter image support not yet implemented")
         user_analysis = rag_service.analyze_user_request(message)
 
         system_prompt = """You are a friendly, expert crochet and knitting instructor and pattern designer. Help users with:
@@ -962,7 +965,7 @@ Always be encouraging and provide practical, actionable advice."""
                         ))
                     contents = parts
                 except (json.JSONDecodeError, base64.binascii.Error) as e:
-                    print(f"Warning: Failed to parse image data: {e}")
+                    logger.warning("Failed to parse image data: %s", e)
                     contents = user_prompt
             else:
                 contents = user_prompt

--- a/backend/app/services/matplotlib_crochet_service.py
+++ b/backend/app/services/matplotlib_crochet_service.py
@@ -11,6 +11,9 @@ import io
 import base64
 from typing import Dict, List, Tuple
 import math
+import logging
+
+logger = logging.getLogger(__name__)
 
 class MatplotlibCrochetService:
     def __init__(self):
@@ -40,7 +43,7 @@ class MatplotlibCrochetService:
         """
         Generate a professional granny square chart based on the actual pattern provided
         """
-        print(f"DEBUG: matplotlib_crochet_service.generate_granny_square_chart called with pattern: {pattern_text[:100]}...")
+        logger.debug("generate_granny_square_chart called with pattern: %s...", pattern_text[:100])
 
         # Create figure with regular (not polar) subplot for better control
         fig, ax = plt.subplots(figsize=self.fig_size, dpi=self.dpi)
@@ -52,11 +55,11 @@ class MatplotlibCrochetService:
 
         # Analyze the pattern to determine structure
         if self._is_traditional_granny_pattern(pattern_text):
-            print("DEBUG: Drawing traditional granny square")
+            logger.debug("Drawing traditional granny square")
             # Traditional granny square with ch-4 ring and corner ch-2 spaces
             self._draw_traditional_granny_square(ax, pattern_text)
         else:
-            print("DEBUG: Drawing circular pattern fallback")
+            logger.debug("Drawing circular pattern fallback")
             # Default to the circular pattern we had before
             self._draw_round_1_cartesian(ax)
             self._draw_round_2_cartesian(ax)


### PR DESCRIPTION
## Heartbeat Auto-Implementation

**What:** ai_service.py has 8+ print() statements (lines 97, 378, 529, 613, 623, 694, 817, 965) and references logger.error at line 128 without importing logging. matplotlib_crochet_service.py has DEBUG print()s at lines 43, 55, 59. main.py uses print() at lines 22-25, 53. Add `import logging; logger = logging.getLogger(__name__)` and replace all print() calls with appropriate logger.info/warning/error calls.
**Why:** The uncommitted diff already fixes one print→logger in ai_service.py:128, but logger is never imported — this will crash at runtime. The remaining 11+ print() calls bypass structured logging, making production debugging and log aggregation impossible.
**Files:** backend/app/services/ai_service.py, backend/app/services/matplotlib_crochet_service.py, backend/app/main.py

---
*Automatically discovered and implemented by Heartbeat on 2026-04-06.*
*Review and merge at your convenience.*

Closes #25