### PR TITLE
heartbeat: Duplicate requests dependency in requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,6 @@ pydantic-settings==2.1.0
 # AI Integration
 google-genai==0.8.0
 httpx==0.25.2
-requests>=2.31.0
 
 # Diagram Generation
 matplotlib==3.8.2


### PR DESCRIPTION
## Heartbeat Auto-Implementation

**What:** Line 16 has `requests>=2.31.0` and line 26 has `requests==2.31.0`. Remove the unpinned `>=` entry, keeping only the pinned `==` version.
**Why:** Contradictory version specs can cause pip resolution issues or install unexpected versions depending on resolution order.
**Files:** backend/requirements.txt

---
*Automatically discovered and implemented by Heartbeat on 2026-04-06.*
*Review and merge at your convenience.*

Closes #29