### PR TITLE
feat: add request logging middleware to FastAPI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,9 @@
 import os
+import time
 import logging
 from fastapi import FastAPI, Request, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from strawberry.fastapi import GraphQLRouter
 from sqlalchemy.orm import Session
 from app.schemas.schema import schema
@@ -36,6 +38,23 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Request logging middleware
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start_time = time.time()
+        response = await call_next(request)
+        duration_ms = (time.time() - start_time) * 1000
+        logger.info(
+            "%s %s %d %.1fms",
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration_ms,
+        )
+        return response
+
+app.add_middleware(RequestLoggingMiddleware)
 
 # Authentication middleware for GraphQL context
 async def get_context(request: Request):


### PR DESCRIPTION
## Summary
- Adds a `RequestLoggingMiddleware` (Starlette `BaseHTTPMiddleware`) that logs method, path, status code, and response time in milliseconds at INFO level for every request.

Closes #22

## Test plan
- [ ] Start backend locally and hit endpoints; verify log lines like `INFO: GET /crooked-finger/health 200 12.3ms`
- [ ] Confirm no impact on existing CORS or auth middleware behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)