### PR TITLE
fix: configure SQLAlchemy connection pooling for production

### DIFF
--- a/backend/app/database/connection.py
+++ b/backend/app/database/connection.py
@@ -3,7 +3,12 @@ from sqlalchemy.orm import sessionmaker
 from app.database.models import Base
 from app.core.config import settings
 
-engine = create_engine(settings.database_url)
+engine = create_engine(
+    settings.database_url,
+    pool_pre_ping=True,
+    pool_size=5,
+    max_overflow=10,
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 def create_tables():


### PR DESCRIPTION
## Summary
- Add `pool_pre_ping=True` to detect and replace stale connections before use
- Set `pool_size=5` and `max_overflow=10` to manage connection pool resources

Closes #21

## Test plan
- [ ] Verify backend starts without errors
- [ ] Confirm database queries work under concurrent load

🤖 Generated with [Claude Code](https://claude.com/claude-code)