### PR TITLE
Re-enable diagram rendering in chat with SVG detection

### DIFF
--- a/backend/app/schemas/mutations.py
+++ b/backend/app/schemas/mutations.py
@@ -497,12 +497,21 @@ class Mutation:
             # Check if the message or response contains pattern information
             has_pattern = contains_pattern_info(message + " " + ai_response)
 
+            # Generate SVG diagram when a diagram was requested and pattern data is available
+            diagram_svg = None
+            if user_analysis.get('requests_diagram'):
+                pattern_text = extract_pattern_text(message, ai_response)
+                if pattern_text:
+                    pattern_data = pattern_service.parse_pattern_structure(pattern_text)
+                    if pattern_data.get('rounds') and len(pattern_data['rounds']) > 0:
+                        diagram_svg = pattern_service.generate_stitch_diagram_svg(pattern_data)
+
             # Store the conversation in database with project_id if provided
             store_chat_message(db, message, ai_response, user.id if user else None, project_id, conversation_id)
 
             return ChatResponse(
                 message=ai_response,
-                diagram_svg=None,
+                diagram_svg=diagram_svg,
                 diagram_png=None,
                 has_pattern=has_pattern
             )

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -484,7 +484,7 @@ CRITICAL FORMATTING RULES:
 
 Format your responses with clear paragraph breaks for readability.
 
-NOTE: Diagram generation is temporarily disabled. When users ask for visual diagrams or charts, politely explain that you can provide detailed written descriptions of patterns instead, including step-by-step instructions and stitch placement explanations.
+When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
 
 Always be encouraging and provide practical, actionable advice."""
 
@@ -636,7 +636,7 @@ Provide detailed, beginner-friendly instructions."""
 - Stitch counting and pattern adjustments
 - Converting between crochet and knitting patterns when possible
 
-NOTE: Diagram generation is temporarily disabled. When users ask for visual diagrams or charts, politely explain that you can provide detailed written descriptions of patterns instead, including step-by-step instructions and stitch placement explanations.
+When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
 
 Always be encouraging and provide practical, actionable advice."""
 
@@ -829,7 +829,7 @@ Provide a clear, step-by-step translation."""
 - Stitch counting and pattern adjustments
 - Converting between crochet and knitting patterns when possible
 
-NOTE: Diagram generation is temporarily disabled. When users ask for visual diagrams or charts, politely explain that you can provide detailed written descriptions of patterns instead, including step-by-step instructions and stitch placement explanations.
+When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
 
 Always be encouraging and provide practical, actionable advice."""
 
@@ -923,7 +923,7 @@ Be thorough, accurate, and encouraging. Focus on making the pattern easy to foll
 
 Format your responses with clear paragraph breaks for readability.
 
-NOTE: Diagram generation is temporarily disabled. When users ask for visual diagrams or charts, politely explain that you can provide detailed written descriptions of patterns instead, including step-by-step instructions and stitch placement explanations.
+When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
 
 Always be encouraging and provide practical, actionable advice."""
 

--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -232,9 +232,41 @@ export function ChatInterface({ chatHistory, onSendMessage, loading = false, con
                             ol: (props) => <ol className="mb-2 ml-4 list-decimal text-card-foreground" {...props} />,
                             li: (props) => <li className="mb-1 text-card-foreground break-words" {...props} />,
                             code: (props) => {
+                              const { className, children, ...rest } = props;
+                              const text = String(children).replace(/\n$/, '');
+                              const isSvgLang = typeof className === 'string' && /language-svg/i.test(className);
+                              const isSvgContent = text.trimStart().startsWith('<svg') && text.includes('</svg>');
+
+                              if (isSvgLang || isSvgContent) {
+                                return (
+                                  <span
+                                    className="diagram-container inline-flex justify-center items-center w-full"
+                                    dangerouslySetInnerHTML={{ __html: text }}
+                                  />
+                                );
+                              }
+
                               return <code className="bg-muted px-1 py-0.5 rounded text-sm font-mono text-card-foreground break-all max-w-full inline-block" {...props} />;
                             },
                             pre: (props) => {
+                              const child = React.Children.only(props.children) as React.ReactElement<{ className?: string; children?: React.ReactNode }>;
+                              if (child?.props) {
+                                const text = String(child.props.children ?? '').replace(/\n$/, '');
+                                const isSvgLang = typeof child.props.className === 'string' && /language-svg/i.test(child.props.className);
+                                const isSvgContent = text.trimStart().startsWith('<svg') && text.includes('</svg>');
+
+                                if (isSvgLang || isSvgContent) {
+                                  return (
+                                    <div className="mt-4 p-4 bg-white rounded-lg border border-border/30 shadow-sm">
+                                      <h4 className="text-sm font-medium text-gray-700 mb-3">Pattern Diagram</h4>
+                                      <div
+                                        className="diagram-container flex justify-center items-center"
+                                        dangerouslySetInnerHTML={{ __html: text }}
+                                      />
+                                    </div>
+                                  );
+                                }
+                              }
                               return <pre className="bg-muted p-2 rounded text-sm font-mono overflow-x-auto text-card-foreground break-all max-w-full" {...props} />;
                             },
                             blockquote: (props) => <blockquote className="border-l-4 border-primary pl-4 italic text-muted-foreground break-words" {...props} />


### PR DESCRIPTION
## Summary
- Add SVG detection to ReactMarkdown `code`/`pre` handlers in ChatInterface so code blocks containing valid SVG (via `language-svg` class or `<svg>...</svg>` content) render as actual diagrams instead of raw markup
- Re-enable backend diagram generation in `chatWithAssistantEnhanced` by calling `pattern_service.generate_stitch_diagram_svg()` when the user request analysis indicates a diagram was requested
- Replace "temporarily disabled" notes in all 4 AI system prompts with guidance that the system auto-generates diagrams alongside responses

Closes #13

## Test plan
- [ ] Send a message asking for a diagram (e.g., "draw a granny square chart") and verify the SVG diagram renders visually in the chat, not as raw code
- [ ] Send a normal message with code blocks and verify they still render as styled code, not as diagrams
- [ ] Verify the `diagramSvg` field in the GraphQL response is populated when a diagram-related message includes pattern data
- [ ] Confirm non-diagram conversations still return `diagramSvg: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)