### PR TITLE
Add backend test infrastructure and critical path tests

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,8 @@
+# Virtual environments
+.venv/
+venv/
+env/
+
 # Python
 __pycache__/
 *.py[cod]
@@ -28,6 +33,9 @@ wheels/
 # Test files with API keys
 test_*_gemini.py
 test_*_api.py
+
+# Test cache
+.pytest_cache/
 
 # IDE
 .vscode/

--- a/backend/app/database/connection.py
+++ b/backend/app/database/connection.py
@@ -3,12 +3,12 @@ from sqlalchemy.orm import sessionmaker
 from app.database.models import Base
 from app.core.config import settings
 
-engine = create_engine(
-    settings.database_url,
-    pool_pre_ping=True,
-    pool_size=5,
-    max_overflow=10,
-)
+_engine_kwargs = {"pool_pre_ping": True}
+if not settings.database_url.startswith("sqlite"):
+    _engine_kwargs["pool_size"] = 5
+    _engine_kwargs["max_overflow"] = 10
+
+engine = create_engine(settings.database_url, **_engine_kwargs)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 def create_tables():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -122,8 +122,8 @@ class AdminControlledGraphQLRouter(GraphQLRouter):
 # Create GraphQL router with admin controls
 graphql_app = AdminControlledGraphQLRouter(
     schema,
-    graphiql=True,
-    context_getter=get_context
+    graphql_ide="graphiql",
+    context_getter=get_context,
 )
 app.include_router(graphql_app, prefix="/crooked-finger/graphql")
 

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+pythonpath = .

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,172 @@
+"""
+Test infrastructure for Crooked Finger backend.
+
+Sets up an in-memory SQLite database and provides fixtures for:
+- Database sessions (isolated per test)
+- Authenticated GraphQL context
+- FastAPI test client
+"""
+import os
+
+# Must set DATABASE_URL before any app module is imported, because
+# app.database.connection creates the SQLAlchemy engine at import time.
+os.environ["DATABASE_URL"] = "sqlite://"
+os.environ["SECRET_KEY"] = "test-secret-key-for-testing"
+os.environ["ADMIN_SECRET"] = "test-admin-secret"
+os.environ["ENVIRONMENT"] = "test"
+os.environ["DEBUG"] = "True"
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker, Session
+
+from app.database.models import Base
+from app.database import connection as db_connection
+from app.utils.auth import get_password_hash, create_access_token
+
+
+# ---------------------------------------------------------------------------
+# SQLite in-memory engine shared across a test session
+# ---------------------------------------------------------------------------
+
+_test_engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+)
+
+# Enable WAL-like behavior: SQLite needs PRAGMA foreign_keys per connection
+@event.listens_for(_test_engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, connection_record):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+TestSessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    bind=_test_engine,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _create_tables():
+    """Create all tables before each test, drop after."""
+    Base.metadata.create_all(bind=_test_engine)
+    yield
+    Base.metadata.drop_all(bind=_test_engine)
+
+
+@pytest.fixture()
+def db_session() -> Session:
+    """Provide a clean database session for a test."""
+    session = TestSessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+@pytest.fixture(autouse=True)
+def _patch_get_db(monkeypatch):
+    """
+    Monkeypatch get_db everywhere it is imported so that mutations
+    and queries use the test database instead of the real one.
+    """
+    def _override_get_db():
+        session = TestSessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    # Patch in the connection module (canonical location)
+    monkeypatch.setattr(db_connection, "get_db", _override_get_db)
+
+    # Patch everywhere get_db was imported by value
+    from app.schemas import mutations as mut_mod
+    from app.schemas import queries as qry_mod
+
+    monkeypatch.setattr(mut_mod, "get_db", _override_get_db)
+    monkeypatch.setattr(qry_mod, "get_db", _override_get_db)
+
+
+# ---------------------------------------------------------------------------
+# User helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def test_user(db_session):
+    """Create and return a test user in the database."""
+    from app.database.models import User
+    from datetime import datetime
+
+    user = User(
+        email="test@example.com",
+        hashed_password=get_password_hash("testpassword123"),
+        is_active=True,
+        is_verified=False,
+        is_admin=False,
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def auth_token(test_user) -> str:
+    """Return a valid JWT for the test user."""
+    return create_access_token(data={"sub": test_user.email})
+
+
+@pytest.fixture()
+def auth_headers(auth_token) -> dict:
+    """Return HTTP headers with a valid Bearer token."""
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+# ---------------------------------------------------------------------------
+# Strawberry schema execution helper
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def execute_query():
+    """
+    Return an async callable that executes a GraphQL operation against
+    the Strawberry schema with optional authentication context.
+    """
+    from app.schemas.schema import schema
+
+    async def _execute(query: str, variables: dict = None, user=None):
+        context = {}
+        if user:
+            context["user"] = user
+        result = await schema.execute(
+            query,
+            variable_values=variables,
+            context_value=context,
+        )
+        return result
+
+    return _execute
+
+
+# ---------------------------------------------------------------------------
+# FastAPI test client
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def client():
+    """Provide a synchronous TestClient for the FastAPI app."""
+    from starlette.testclient import TestClient
+    from app.main import app
+
+    with TestClient(app) as c:
+        yield c

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,106 @@
+"""
+Tests for authentication mutations: register and login.
+
+Critical path: these are the entry points for every user session.
+"""
+import pytest
+
+
+REGISTER_MUTATION = """
+mutation Register($input: RegisterInput!) {
+    register(input: $input) {
+        user {
+            id
+            email
+            isActive
+        }
+        accessToken
+        tokenType
+    }
+}
+"""
+
+LOGIN_MUTATION = """
+mutation Login($input: LoginInput!) {
+    login(input: $input) {
+        user {
+            id
+            email
+            isActive
+        }
+        accessToken
+        tokenType
+    }
+}
+"""
+
+
+class TestRegister:
+    """Register mutation tests."""
+
+    @pytest.mark.asyncio
+    async def test_register_creates_user(self, execute_query):
+        """A new user can register and receives a valid JWT."""
+        result = await execute_query(
+            REGISTER_MUTATION,
+            variables={"input": {"email": "new@example.com", "password": "securepass123"}},
+        )
+        assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+        data = result.data["register"]
+        assert data["user"]["email"] == "new@example.com"
+        assert data["user"]["isActive"] is True
+        assert data["accessToken"]  # non-empty string
+        assert data["tokenType"] == "bearer"
+
+    @pytest.mark.asyncio
+    async def test_register_duplicate_email_fails(self, execute_query):
+        """Registering with an already-taken email returns an error."""
+        variables = {"input": {"email": "dup@example.com", "password": "pass123"}}
+
+        # First registration succeeds
+        result1 = await execute_query(REGISTER_MUTATION, variables=variables)
+        assert result1.errors is None
+
+        # Second registration with same email fails
+        result2 = await execute_query(REGISTER_MUTATION, variables=variables)
+        assert result2.errors is not None
+        assert any("already exists" in str(e) for e in result2.errors)
+
+
+class TestLogin:
+    """Login mutation tests."""
+
+    @pytest.mark.asyncio
+    async def test_login_with_valid_credentials(self, execute_query, test_user):
+        """A registered user can log in and gets a JWT."""
+        result = await execute_query(
+            LOGIN_MUTATION,
+            variables={"input": {"email": "test@example.com", "password": "testpassword123"}},
+        )
+        assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+        data = result.data["login"]
+        assert data["user"]["email"] == "test@example.com"
+        assert data["accessToken"]
+        assert data["tokenType"] == "bearer"
+
+    @pytest.mark.asyncio
+    async def test_login_with_wrong_password(self, execute_query, test_user):
+        """Login with incorrect password returns an error."""
+        result = await execute_query(
+            LOGIN_MUTATION,
+            variables={"input": {"email": "test@example.com", "password": "wrongpassword"}},
+        )
+        assert result.errors is not None
+        assert any("Incorrect email or password" in str(e) for e in result.errors)
+
+    @pytest.mark.asyncio
+    async def test_login_nonexistent_user(self, execute_query):
+        """Login with an email that does not exist returns an error."""
+        result = await execute_query(
+            LOGIN_MUTATION,
+            variables={"input": {"email": "nobody@example.com", "password": "whatever"}},
+        )
+        assert result.errors is not None
+        assert any("Incorrect email or password" in str(e) for e in result.errors)

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -1,0 +1,141 @@
+"""
+Tests for conversation mutations and queries.
+
+Critical path: conversations are the primary container for chat messages
+and sync across web and iOS clients.
+"""
+import pytest
+
+
+CREATE_CONVERSATION = """
+mutation CreateConversation($input: CreateConversationInput!) {
+    createConversation(input: $input) {
+        id
+        title
+        userId
+        messageCount
+    }
+}
+"""
+
+LIST_CONVERSATIONS = """
+query Conversations {
+    conversations {
+        id
+        title
+        userId
+        messageCount
+    }
+}
+"""
+
+DELETE_CONVERSATION = """
+mutation DeleteConversation($conversationId: Int!) {
+    deleteConversation(conversationId: $conversationId)
+}
+"""
+
+
+class TestCreateConversation:
+    """Create conversation mutation tests."""
+
+    @pytest.mark.asyncio
+    async def test_create_conversation_authenticated(self, execute_query, test_user):
+        """An authenticated user can create a conversation."""
+        result = await execute_query(
+            CREATE_CONVERSATION,
+            variables={"input": {"title": "My Granny Square Chat"}},
+            user=test_user,
+        )
+        assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+        data = result.data["createConversation"]
+        assert data["title"] == "My Granny Square Chat"
+        assert data["userId"] == test_user.id
+        assert data["messageCount"] == 0
+
+    @pytest.mark.asyncio
+    async def test_create_conversation_default_title(self, execute_query, test_user):
+        """A conversation created without a title gets the default."""
+        result = await execute_query(
+            CREATE_CONVERSATION,
+            variables={"input": {}},
+            user=test_user,
+        )
+        assert result.errors is None, f"GraphQL errors: {result.errors}"
+        assert result.data["createConversation"]["title"] == "New Chat"
+
+    @pytest.mark.asyncio
+    async def test_create_conversation_unauthenticated(self, execute_query):
+        """Creating a conversation without auth returns an error."""
+        result = await execute_query(
+            CREATE_CONVERSATION,
+            variables={"input": {"title": "Sneaky"}},
+            user=None,
+        )
+        assert result.errors is not None
+        assert any("Authentication required" in str(e) for e in result.errors)
+
+
+class TestListConversations:
+    """Conversation listing query tests."""
+
+    @pytest.mark.asyncio
+    async def test_list_conversations_returns_user_conversations(
+        self, execute_query, test_user
+    ):
+        """Listing conversations returns only the authenticated user's data."""
+        # Create two conversations
+        await execute_query(
+            CREATE_CONVERSATION,
+            variables={"input": {"title": "Chat 1"}},
+            user=test_user,
+        )
+        await execute_query(
+            CREATE_CONVERSATION,
+            variables={"input": {"title": "Chat 2"}},
+            user=test_user,
+        )
+
+        result = await execute_query(LIST_CONVERSATIONS, user=test_user)
+        assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+        conversations = result.data["conversations"]
+        assert len(conversations) == 2
+        titles = {c["title"] for c in conversations}
+        assert titles == {"Chat 1", "Chat 2"}
+
+    @pytest.mark.asyncio
+    async def test_list_conversations_unauthenticated_returns_empty(self, execute_query):
+        """An unauthenticated request gets an empty list, not an error."""
+        result = await execute_query(LIST_CONVERSATIONS, user=None)
+        assert result.errors is None
+        assert result.data["conversations"] == []
+
+
+class TestDeleteConversation:
+    """Delete conversation mutation tests."""
+
+    @pytest.mark.asyncio
+    async def test_delete_conversation(self, execute_query, test_user):
+        """An authenticated user can delete their own conversation."""
+        # Create a conversation
+        create_result = await execute_query(
+            CREATE_CONVERSATION,
+            variables={"input": {"title": "To Be Deleted"}},
+            user=test_user,
+        )
+        conv_id = create_result.data["createConversation"]["id"]
+
+        # Delete it
+        delete_result = await execute_query(
+            DELETE_CONVERSATION,
+            variables={"conversationId": conv_id},
+            user=test_user,
+        )
+        assert delete_result.errors is None
+        assert delete_result.data["deleteConversation"] is True
+
+        # Verify it is gone
+        list_result = await execute_query(LIST_CONVERSATIONS, user=test_user)
+        assert len(list_result.data["conversations"]) == 0

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,27 @@
+"""
+Tests for the FastAPI health and root endpoints.
+
+These are the simplest smoke tests to confirm the app boots
+and responds to basic HTTP requests.
+"""
+import pytest
+
+
+class TestHealthEndpoint:
+    """Health check endpoint tests."""
+
+    def test_health_returns_200(self, client):
+        """The /crooked-finger/health endpoint returns 200 with expected body."""
+        response = client.get("/crooked-finger/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "healthy"
+        assert body["service"] == "crooked-finger"
+
+    def test_root_returns_200(self, client):
+        """The root endpoint returns service metadata."""
+        response = client.get("/")
+        assert response.status_code == 200
+        body = response.json()
+        assert "Crooked Finger" in body["message"]
+        assert "graphql" in body["endpoints"]


### PR DESCRIPTION
## Summary
- Add `conftest.py` with SQLite in-memory database fixtures, monkeypatched `get_db`, and Strawberry schema execution helpers for isolated test runs
- Add 13 tests covering auth mutations (register/login), conversation CRUD (create/list/delete), and health endpoints
- Fix `connection.py` to skip PostgreSQL-only pool kwargs when using SQLite, enabling tests without a running database
- Update `main.py` `GraphQLRouter` from deprecated `graphiql=True` to `graphql_ide="graphiql"`

## Test plan
- [x] `pytest tests/` passes: 42 tests (29 existing + 13 new), 0 failures, ~1s runtime
- [x] Auth tests verify register creates user with JWT, duplicate email rejected, login works with valid creds, wrong password rejected
- [x] Conversation tests verify authenticated CRUD, unauthenticated rejection, default title
- [x] Health tests verify `/crooked-finger/health` and `/` return expected responses
- [ ] Verify production deployment still works (connection.py change is backward-compatible)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)