### PR TITLE
Migrate AI cascade to z.ai Anthropic proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ next-env.d.ts
 backend/crooked_finger.db
 .env
 .mcp.json
+.grepai/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,10 +13,11 @@ ACCESS_TOKEN_EXPIRE_MINUTES=10080
 ADMIN_SECRET=change-me-to-a-random-secret
 
 # --- AI Services ---
-# Google Gemini (https://aistudio.google.com/apikey)
-GEMINI_API_KEY=
-# OpenRouter for free fallback models (https://openrouter.ai/keys)
-OPENROUTER_API_KEY=
+# z.ai subscription key — Anthropic-compatible proxy.
+# The endpoint is hardcoded to https://api.z.ai/api/anthropic; this key is all
+# that is needed. Behind the scenes z.ai routes Anthropic model IDs to its own
+# GLM models (claude-sonnet-4-5-20250929 -> GLM-4.7).
+ZAI_API_KEY=
 
 # --- Application ---
 ENVIRONMENT=development

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,9 +9,8 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 10080  # 7 days
 
-    # External API Keys
-    gemini_api_key: Optional[str] = None
-    openrouter_api_key: Optional[str] = None
+    # AI provider: z.ai exposes an Anthropic-compatible proxy
+    zai_api_key: Optional[str] = None
 
     # Environment
     environment: str = "development"

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -195,7 +195,7 @@ class AIService:
         """Translate crochet/knitting notation into readable instructions."""
         client = self._get_client()
         if client is None:
-            return _fallback_translation(pattern_text)
+            return "AI service not configured. Please set ZAI_API_KEY."
 
         user_prompt = (
             "Please translate this crochet or knitting pattern into clear, "
@@ -371,38 +371,6 @@ def _extract_text(response: Any) -> str:
             if text:
                 parts.append(text)
     return "".join(parts)
-
-
-def _fallback_translation(pattern_text: str) -> str:
-    """Basic abbreviation expansion used when ZAI_API_KEY is missing."""
-    abbreviations = {
-        "sc": "single crochet",
-        "dc": "double crochet",
-        "hdc": "half double crochet",
-        "tc": "treble crochet",
-        "sl st": "slip stitch",
-        "ch": "chain",
-        "st": "stitch",
-        "sts": "stitches",
-        "inc": "increase",
-        "dec": "decrease",
-        "yo": "yarn over",
-        "sk": "skip",
-        "rep": "repeat",
-        "rnd": "round",
-        "beg": "beginning",
-        "sp": "space",
-        "tog": "together",
-    }
-    translated = pattern_text
-    for abbrev, full_form in abbreviations.items():
-        translated = translated.replace(abbrev, full_form)
-    return (
-        "Basic translation (AI not available):\n\n"
-        f"{translated}\n\n"
-        "Note: This is a simple translation. For detailed instructions, "
-        "please configure ZAI_API_KEY."
-    )
 
 
 # Global instance (maintained so existing imports keep working).

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,397 +1,57 @@
-from google import genai
-from google.genai import types
-from typing import Optional, Dict, Any
-from enum import Enum
-from datetime import date, datetime
-from sqlalchemy.orm import Session
+"""
+AI service for Crooked Finger.
+
+Uses a single Anthropic SDK client pointed at z.ai's Anthropic-compatible
+proxy. Behind the scenes z.ai routes Anthropic model IDs to GLM models:
+- claude-sonnet-4-5-20250929 -> GLM-4.7 (high quality, default)
+- claude-haiku-4-5-20251001  -> GLM-4.5-Air (medium quality)
+
+The previous Gemini/OpenRouter cascade (8 provider methods, smart routing,
+fallback chains, per-model quota tracking) has been collapsed into a single
+client because z.ai handles routing internally.
+
+The GraphQL surface (usage dashboard, provider config, set-model, reset-usage)
+is preserved as no-op / single-model stubs so the frontend does not need to
+change in this phase.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from anthropic import Anthropic
+
 from app.core.config import settings
 from app.services.rag_service import rag_service
-from app.database.models import AIModelUsage
-from app.database.connection import SessionLocal
-import httpx
-import json
-import base64
-import logging
 
 logger = logging.getLogger(__name__)
 
-class GeminiModel(Enum):
-    """Available Gemini models with their daily limits and characteristics"""
-    PRO = {
-        "name": "gemini-2.5-pro",
-        "daily_limit": 100,
-        "priority": 1,
-        "use_case": "complex_analysis"
-    }
-    FLASH_PREVIEW = {
-        "name": "gemini-2.5-flash-preview-09-2025",
-        "daily_limit": 250,
-        "priority": 2,
-        "use_case": "general_chat"
-    }
-    FLASH = {
-        "name": "gemini-2.5-flash",
-        "daily_limit": 250,
-        "priority": 3,
-        "use_case": "general_chat"
-    }
-    FLASH_LITE = {
-        "name": "gemini-2.5-flash-lite",
-        "daily_limit": 1000,
-        "priority": 4,
-        "use_case": "simple_queries"
-    }
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 
-class AIService:
-    # All available models
-    ALL_AVAILABLE_MODELS = {
-        # OpenRouter free models
-        "deepseek/deepseek-chat-v3.1:free": {"provider": "openrouter", "name": "DeepSeek Chat v3.1", "cost": "free"},
-        "qwen/qwen3-30b-a3b:free": {"provider": "openrouter", "name": "Qwen3 30B A3B (Often Unavailable)", "cost": "free"},
-        # Gemini models
-        "gemini-2.5-pro": {"provider": "gemini", "name": "Gemini 2.5 Pro", "daily_limit": 100},
-        "gemini-2.5-flash-preview-09-2025": {"provider": "gemini", "name": "Gemini 2.5 Flash Preview", "daily_limit": 250},
-        "gemini-2.5-flash": {"provider": "gemini", "name": "Gemini 2.5 Flash", "daily_limit": 250},
-        "gemini-2.5-flash-lite": {"provider": "gemini", "name": "Gemini 2.5 Flash Lite", "daily_limit": 1000},
-    }
+# z.ai exposes the Anthropic Messages API at this path. The `/v1/messages`
+# suffix is appended by the Anthropic SDK itself, so we stop at `/anthropic`.
+ZAI_BASE_URL = "https://api.z.ai/api/anthropic"
 
-    # Default OpenRouter model priority (will try in order)
-    # Note: Qwen removed from default as it's frequently unavailable (503 errors)
-    DEFAULT_OPENROUTER_MODELS = [
-        "deepseek/deepseek-chat-v3.1:free",  # Primary: DeepSeek v3.1 (unlimited, reliable)
-    ]
+# Default model used for all calls. z.ai routes this to GLM-4.7 internally.
+DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
 
-    def __init__(self):
-        self.gemini_api_key = settings.gemini_api_key
-        self.openrouter_api_key = getattr(settings, 'openrouter_api_key', None)
-        self.client = None
+# Token budgets. Anthropic requires max_tokens; picking generous limits that
+# match the old behavior (Gemini calls had no explicit cap and returned full
+# long-form responses for pattern translation).
+MAX_TOKENS_TRANSLATE = 4096
+MAX_TOKENS_CHAT = 4096
 
-        # Load persisted configuration from database
-        self._load_config_from_db()
 
-        # If no config in DB, use defaults
-        if not hasattr(self, '_selected_model'):
-            self.use_openrouter_default = False  # Don't default to OpenRouter
-            self._ai_provider_preference = "auto"  # "openrouter", "gemini", or "auto"
-            self._selected_model = None  # Specific model or None for smart routing
-            self._model_priority_order = []  # Empty = smart routing, not fallback
+# ---------------------------------------------------------------------------
+# System prompts (preserved verbatim from the Gemini implementation so that
+# output quality/voice does not regress).
+# ---------------------------------------------------------------------------
 
-    def _load_config_from_db(self):
-        """Load AI model configuration from database"""
-        from app.database.models import AIModelConfig
-        db = SessionLocal()
-        try:
-            config = db.query(AIModelConfig).first()
-            if config:
-                self._selected_model = config.selected_model
-                self._model_priority_order = config.model_priority_order or []
-                self._ai_provider_preference = config.provider_preference or "auto"
-
-                # Set use_openrouter_default based on configuration
-                if self._selected_model:
-                    model_info = self.ALL_AVAILABLE_MODELS.get(self._selected_model)
-                    self.use_openrouter_default = model_info and model_info["provider"] == "openrouter"
-                elif self._model_priority_order:
-                    self.use_openrouter_default = True
-                else:
-                    self.use_openrouter_default = False
-        except Exception as e:
-            # Table may not exist yet (before migration runs)
-            logger.warning("Could not load AI config from database (table may not exist yet): %s", e)
-            pass
-        finally:
-            db.close()
-
-    def _save_config_to_db(self):
-        """Save AI model configuration to database"""
-        from app.database.models import AIModelConfig
-        db = SessionLocal()
-        try:
-            config = db.query(AIModelConfig).first()
-            if not config:
-                config = AIModelConfig()
-                db.add(config)
-
-            config.selected_model = self._selected_model
-            config.model_priority_order = self._model_priority_order
-            config.provider_preference = self._ai_provider_preference
-            config.updated_at = datetime.utcnow()
-
-            db.commit()
-        finally:
-            db.close()
-
-    def _get_client(self):
-        """Lazy initialization of Gemini client"""
-        if self.client is None and self.gemini_api_key:
-            try:
-                # Use direct API key parameter (proven to work)
-                self.client = genai.Client(api_key=self.gemini_api_key)
-            except Exception as e:
-                logger.error("Failed to create Gemini client with direct API key: %s", e)
-                return None
-        return self.client
-
-    def _get_usage_for_date(self, db: Session, model_name: str, target_date: date) -> int:
-        """Get current usage count for a model on a specific date"""
-        usage = db.query(AIModelUsage).filter(
-            AIModelUsage.model_name == model_name,
-            AIModelUsage.date == target_date
-        ).first()
-        return usage.request_count if usage else 0
-
-    def _increment_usage(self, db: Session, model_name: str, input_chars: int = 0, output_chars: int = 0) -> None:
-        """Increment usage count for a model today with character/token tracking"""
-        today = date.today()
-        usage = db.query(AIModelUsage).filter(
-            AIModelUsage.model_name == model_name,
-            AIModelUsage.date == today
-        ).first()
-
-        # Estimate tokens (rough approximation: 1 token ≈ 4 characters)
-        input_tokens = input_chars // 4
-        output_tokens = output_chars // 4
-
-        if usage:
-            usage.request_count += 1
-            usage.total_input_characters += input_chars
-            usage.total_output_characters += output_chars
-            usage.total_input_tokens += input_tokens
-            usage.total_output_tokens += output_tokens
-            usage.updated_at = datetime.utcnow()
-        else:
-            usage = AIModelUsage(
-                model_name=model_name,
-                request_count=1,
-                total_input_characters=input_chars,
-                total_output_characters=output_chars,
-                total_input_tokens=input_tokens,
-                total_output_tokens=output_tokens,
-                date=today
-            )
-            db.add(usage)
-        db.commit()
-
-    def reset_daily_usage(self) -> Dict[str, Any]:
-        """Reset all AI model usage for today"""
-        db = SessionLocal()
-        try:
-            today = date.today()
-
-            # Delete all usage records for today
-            deleted_count = db.query(AIModelUsage).filter(
-                AIModelUsage.date == today
-            ).delete()
-
-            db.commit()
-
-            return {
-                "success": True,
-                "message": f"Reset usage for {deleted_count} model entries on {today}",
-                "reset_date": today.isoformat()
-            }
-
-        except Exception as e:
-            db.rollback()
-            return {
-                "success": False,
-                "message": f"Failed to reset usage: {str(e)}",
-                "reset_date": None
-            }
-        finally:
-            db.close()
-
-    def _select_best_available_model(self, complexity: str = "general") -> Optional[GeminiModel]:
-        """Select the best available model based on complexity and current usage"""
-        db = SessionLocal()
-        try:
-            today = date.today()
-
-            # Determine preferred models based on complexity
-            # Flash-Lite is always last resort due to lower quality
-            if complexity == "complex":
-                # For complex tasks, prefer Pro > Flash Preview > Flash > Flash-Lite
-                preferred_order = [GeminiModel.PRO, GeminiModel.FLASH_PREVIEW, GeminiModel.FLASH, GeminiModel.FLASH_LITE]
-            elif complexity == "simple":
-                # For simple tasks, prefer Flash > Flash Preview > Pro > Flash-Lite (Flash is efficient)
-                preferred_order = [GeminiModel.FLASH, GeminiModel.FLASH_PREVIEW, GeminiModel.PRO, GeminiModel.FLASH_LITE]
-            else:
-                # For general tasks, prefer Flash Preview > Flash > Pro > Flash-Lite
-                preferred_order = [GeminiModel.FLASH_PREVIEW, GeminiModel.FLASH, GeminiModel.PRO, GeminiModel.FLASH_LITE]
-
-            # Find first available model with quota remaining
-            for model in preferred_order:
-                current_usage = self._get_usage_for_date(db, model.value["name"], today)
-                if current_usage < model.value["daily_limit"]:
-                    return model
-
-            # If all models are at limit, return None
-            return None
-        finally:
-            db.close()
-
-    def get_usage_stats(self) -> Dict[str, Dict[str, Any]]:
-        """Get current usage statistics for all models"""
-        db = SessionLocal()
-        try:
-            today = date.today()
-            stats = {}
-
-            # Add Gemini models
-            for model in GeminiModel:
-                model_name = model.value["name"]
-                usage_record = db.query(AIModelUsage).filter(
-                    AIModelUsage.model_name == model_name,
-                    AIModelUsage.date == today
-                ).first()
-
-                current_usage = usage_record.request_count if usage_record else 0
-                daily_limit = model.value["daily_limit"]
-
-                stats[model_name] = {
-                    "current_usage": current_usage,
-                    "daily_limit": daily_limit,
-                    "remaining": daily_limit - current_usage,
-                    "percentage_used": round((current_usage / daily_limit) * 100, 1),
-                    "priority": model.value["priority"],
-                    "use_case": model.value["use_case"],
-                    "total_input_characters": usage_record.total_input_characters if usage_record else 0,
-                    "total_output_characters": usage_record.total_output_characters if usage_record else 0,
-                    "total_input_tokens": usage_record.total_input_tokens if usage_record else 0,
-                    "total_output_tokens": usage_record.total_output_tokens if usage_record else 0,
-                }
-
-            # Add OpenRouter models (unlimited, so always show as available)
-            for model_name, info in self.ALL_AVAILABLE_MODELS.items():
-                if info["provider"] == "openrouter":
-                    usage_record = db.query(AIModelUsage).filter(
-                        AIModelUsage.model_name == model_name,
-                        AIModelUsage.date == today
-                    ).first()
-
-                    current_usage = usage_record.request_count if usage_record else 0
-
-                    stats[model_name] = {
-                        "current_usage": current_usage,
-                        "daily_limit": 999999,  # Unlimited
-                        "remaining": 999999,
-                        "percentage_used": 0,
-                        "priority": 0,
-                        "use_case": "unlimited",
-                        "total_input_characters": usage_record.total_input_characters if usage_record else 0,
-                        "total_output_characters": usage_record.total_output_characters if usage_record else 0,
-                        "total_input_tokens": usage_record.total_input_tokens if usage_record else 0,
-                        "total_output_tokens": usage_record.total_output_tokens if usage_record else 0,
-                    }
-
-            return stats
-        finally:
-            db.close()
-
-    async def translate_crochet_pattern(self, pattern_text: str, user_context: str = "") -> str:
-        """
-        Translate crochet pattern notation into readable instructions using configured model
-        """
-        # If specific model is selected, use it directly
-        if self._selected_model:
-            model_info = self.ALL_AVAILABLE_MODELS.get(self._selected_model)
-            if model_info:
-                if model_info["provider"] == "openrouter":
-                    return await self._translate_with_specific_openrouter_model(pattern_text, user_context, self._selected_model)
-                elif model_info["provider"] == "gemini":
-                    return await self._translate_with_specific_gemini_model(pattern_text, user_context, self._selected_model)
-
-        # If fallback chain is configured (non-empty priority order), use it
-        if self._model_priority_order:
-            return await self._translate_with_openrouter(pattern_text, user_context)
-
-        # Smart routing: Pattern translation is complex, prefer higher-tier models
-        client = self._get_client()
-        if client:
-            return await self._translate_with_gemini(pattern_text, user_context, complexity="complex")
-        else:
-            return self._fallback_translation(pattern_text)
-
-    async def chat_about_pattern(self, message: str, project_context: str = "", chat_history: str = "", image_data: Optional[str] = None) -> str:
-        """
-        Chat with AI about crochet patterns and techniques using configured model
-        Supports image analysis when image_data is provided (JSON array of base64 strings)
-        """
-        # If specific model is selected, use it directly
-        if self._selected_model:
-            model_info = self.ALL_AVAILABLE_MODELS.get(self._selected_model)
-            if model_info:
-                if model_info["provider"] == "openrouter":
-                    return await self._chat_with_specific_openrouter_model(message, project_context, chat_history, self._selected_model, image_data)
-                elif model_info["provider"] == "gemini":
-                    return await self._chat_with_specific_gemini_model(message, project_context, chat_history, self._selected_model, image_data)
-
-        # If fallback chain is configured (non-empty priority order), use it
-        if self._model_priority_order:
-            return await self._chat_with_openrouter(message, project_context, chat_history, image_data)
-
-        # Smart routing: use complexity-based selection
-        client = self._get_client()
-        if client:
-            complexity = self._analyze_message_complexity(message)
-            return await self._chat_with_gemini(message, project_context, chat_history, complexity=complexity, image_data=image_data)
-        else:
-            return "AI service not configured. Please set GEMINI_API_KEY."
-
-    def _analyze_message_complexity(self, message: str) -> str:
-        """Analyze message to determine appropriate model complexity"""
-        message_lower = message.lower()
-
-        # Complex indicators
-        complex_keywords = [
-            "diagram", "chart", "pattern", "translate", "convert",
-            "calculate", "design", "modify", "complex", "advanced"
-        ]
-
-        # Simple indicators
-        simple_keywords = [
-            "what is", "define", "meaning", "abbreviation", "mean",
-            "hello", "hi", "thanks", "thank you"
-        ]
-
-        if any(keyword in message_lower for keyword in complex_keywords):
-            return "complex"
-        elif any(keyword in message_lower for keyword in simple_keywords):
-            return "simple"
-        else:
-            return "general"
-
-    def _detect_mime_type(self, data: bytes) -> str:
-        """Detect MIME type from file magic bytes"""
-        # Check magic bytes (file signatures)
-        if data[:4] == b'%PDF':
-            return "application/pdf"
-        elif data[:2] == b'\xff\xd8':
-            return "image/jpeg"
-        elif data[:8] == b'\x89PNG\r\n\x1a\n':
-            return "image/png"
-        elif data[:6] in (b'GIF87a', b'GIF89a'):
-            return "image/gif"
-        elif data[:2] in (b'BM', b'BA'):
-            return "image/bmp"
-        elif data[:4] == b'RIFF' and data[8:12] == b'WEBP':
-            return "image/webp"
-        else:
-            # Default to JPEG if unknown (most common for photos)
-            logger.warning("Unknown file type, defaulting to image/jpeg. First bytes: %s", data[:10].hex())
-            return "image/jpeg"
-
-    async def _translate_with_gemini(self, pattern_text: str, context: str, complexity: str = "complex") -> str:
-        """Use best available Gemini model for pattern translation"""
-        try:
-            # Select best available model
-            selected_model = self._select_best_available_model(complexity)
-            if not selected_model:
-                return "All AI models have reached their daily limits. Please try again tomorrow."
-
-            model_name = selected_model.value["name"]
-
-            system_prompt = """You are an expert crochet and knitting instructor. Your job is to translate standard crochet and knitting notation into clear, easy-to-follow instructions for beginners and intermediate crafters.
+TRANSLATE_SYSTEM_PROMPT = """You are an expert crochet and knitting instructor. Your job is to translate standard crochet and knitting notation into clear, easy-to-follow instructions for beginners and intermediate crafters.
 
 Rules for translation:
 - Expand all abbreviations (sc = single crochet, dc = double crochet, k = knit, p = purl, etc.)
@@ -401,59 +61,27 @@ Rules for translation:
 - Use encouraging, friendly language
 - Include warnings about common mistakes"""
 
-            user_prompt = f"""Please translate this crochet or knitting pattern into clear, step-by-step instructions:
+CHAT_SYSTEM_PROMPT = """You are a friendly, expert crochet and knitting instructor and pattern designer. Help users with:
+- Crochet and knitting technique questions
+- Pattern interpretation and clarification
+- Troubleshooting common problems
+- Yarn, fiber, and hook/needle recommendations
+- Project planning and modifications
+- Stitch counting and pattern adjustments
+- Converting between crochet and knitting patterns when possible
 
-PATTERN:
-{pattern_text}
+Format your responses with clear paragraph breaks for readability.
 
-{f'CONTEXT: {context}' if context else ''}
+When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
 
-Provide detailed, beginner-friendly instructions."""
+Always be encouraging and provide practical, actionable advice."""
 
-            # Combine system and user prompts for Gemini
-            combined_prompt = f"{system_prompt}\n\n{user_prompt}"
-
-            client = self._get_client()
-            response = client.models.generate_content(
-                model=model_name,
-                contents=combined_prompt
-            )
-
-            # Track usage with character counts
-            db = SessionLocal()
-            try:
-                input_chars = len(combined_prompt)
-                output_chars = len(response.text)
-                self._increment_usage(db, model_name, input_chars, output_chars)
-            finally:
-                db.close()
-
-            return f"[{model_name}] {response.text}"
-
-        except Exception as e:
-            return f"Error translating pattern: {str(e)}"
-
-    async def _chat_with_gemini(self, message: str, project_context: str, chat_history: str, complexity: str = "general", image_data: Optional[str] = None) -> str:
-        """Use best available Gemini model for crochet chat with RAG enhancement and image support"""
-        try:
-            # Select best available model
-            selected_model = self._select_best_available_model(complexity)
-            if not selected_model:
-                return "All AI models have reached their daily limits. Please try again tomorrow."
-
-            model_name = selected_model.value["name"]
-
-            # Use RAG to analyze user request and enhance context
-            user_analysis = rag_service.analyze_user_request(message)
-
-            # Enhanced system prompt for image analysis
-            if image_data:
-                system_prompt = """You are an expert crochet and knitting instructor and pattern designer. Analyze the image and extract the crochet or knitting pattern.
+IMAGE_CHAT_SYSTEM_PROMPT = """You are an expert crochet and knitting instructor and pattern designer. Analyze the image and extract the crochet or knitting pattern.
 
 Format your response EXACTLY like this example (do NOT use numbered lists):
 
 NAME: Cat's Cradle Blanket
-NOTATION: Foundation Chain: Ch 122. Row 1: Dc in 3rd ch from hook and in each ch across, ch 2, turn — 120 dc. Row 2: Dc in 1st st, *Fpdc around the next 2 sts, Bpdc around the next 2 sts; rep from * to last st, dc in last st, ch 2, turn.
+NOTATION: Foundation Chain: Ch 122. Row 1: Dc in 3rd ch from hook and in each ch across, ch 2, turn - 120 dc. Row 2: Dc in 1st st, *Fpdc around the next 2 sts, Bpdc around the next 2 sts; rep from * to last st, dc in last st, ch 2, turn.
 INSTRUCTIONS:
 Round 1: Make a magic ring. Chain 2, work 12 double crochet into the ring. Pull the ring tight and slip stitch to join.
 
@@ -472,634 +100,310 @@ CRITICAL FORMATTING RULES:
 - Write INSTRUCTIONS as complete sentences, not abbreviated notation
 - Separate each major section with blank lines
 - Use the exact header format: "NAME:", "NOTATION:", "INSTRUCTIONS:", etc."""
-            else:
-                system_prompt = """You are a friendly, expert crochet and knitting instructor and pattern designer. Help users with:
-- Crochet and knitting technique questions
-- Pattern interpretation and clarification
-- Troubleshooting common problems
-- Yarn, fiber, and hook/needle recommendations
-- Project planning and modifications
-- Stitch counting and pattern adjustments
-- Converting between crochet and knitting patterns when possible
-
-Format your responses with clear paragraph breaks for readability.
-
-When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
-
-Always be encouraging and provide practical, actionable advice."""
-
-            # Enhance context with RAG if diagram is requested
-            context_info = ""
-            if project_context:
-                context_info += f"\nCURRENT PROJECT CONTEXT:\n{project_context}\n"
-            if chat_history:
-                context_info += f"\nPREVIOUS CONVERSATION:\n{chat_history}\n"
-
-            # Add RAG enhancement for diagram requests
-            if user_analysis['requests_diagram']:
-                # Extract any pattern from the message for RAG enhancement
-                pattern_text = message if any(pe in message.lower() for pe in ['round', 'row', 'chain', 'dc', 'sc']) else ""
-                if pattern_text:
-                    rag_enhancement = rag_service.enhance_pattern_context(pattern_text, message)
-                    context_info += f"\n{rag_enhancement}\n"
-
-            user_prompt = f"{context_info}\nUSER QUESTION: {message}"
-
-            # Combine system and user prompts for Gemini
-            combined_prompt = f"{system_prompt}\n\n{user_prompt}"
-
-            client = self._get_client()
-
-            # Build contents array with text and images if provided
-            if image_data:
-                try:
-                    image_list = json.loads(image_data)
-                    # Create parts list with text and images
-                    parts = [combined_prompt]
-                    for img_base64 in image_list:
-                        # Gemini SDK expects Part objects with inline_data
-                        img_bytes = base64.b64decode(img_base64)
-
-                        # Detect MIME type from magic bytes
-                        mime_type = self._detect_mime_type(img_bytes)
-
-                        parts.append(types.Part.from_bytes(
-                            data=img_bytes,
-                            mime_type=mime_type
-                        ))
-                    contents = parts
-                except (json.JSONDecodeError, base64.binascii.Error) as e:
-                    logger.warning("Failed to parse image data: %s", e)
-                    contents = combined_prompt
-            else:
-                contents = combined_prompt
-
-            response = client.models.generate_content(
-                model=model_name,
-                contents=contents
-            )
-
-            # Track usage with character counts
-            db = SessionLocal()
-            try:
-                input_chars = len(combined_prompt)
-                output_chars = len(response.text)
-                self._increment_usage(db, model_name, input_chars, output_chars)
-            finally:
-                db.close()
-
-            return f"[{model_name}] {response.text}"
-
-        except Exception as e:
-            return f"Sorry, I'm having trouble responding right now: {str(e)}"
 
 
-    async def _translate_with_openrouter(self, pattern_text: str, context: str) -> str:
-        """Use OpenRouter models for pattern translation with fallback"""
-        system_prompt = """You are an expert crochet and knitting instructor. Your job is to translate standard crochet and knitting notation into clear, easy-to-follow instructions for beginners and intermediate crafters.
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-Rules for translation:
-- Expand all abbreviations (sc = single crochet, dc = double crochet, k = knit, p = purl, etc.)
-- Break down complex instructions into numbered steps
-- Explain stitch counts and placement clearly
-- Add helpful tips for tricky techniques
-- Use encouraging, friendly language
-- Include warnings about common mistakes"""
+def _detect_mime_type(data: bytes) -> str:
+    """Detect an image mime type from its magic bytes.
 
-        user_prompt = f"""Please translate this crochet or knitting pattern into clear, step-by-step instructions:
+    Anthropic image blocks only accept image/* types. PDFs are rejected;
+    callers should convert to images beforehand. If we get a PDF here we
+    return "image/jpeg" to let Anthropic produce a useful error rather than
+    silently dropping the data.
+    """
+    if data[:2] == b"\xff\xd8":
+        return "image/jpeg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    logger.warning(
+        "Unknown image type, defaulting to image/jpeg. First bytes: %s",
+        data[:10].hex(),
+    )
+    return "image/jpeg"
 
-PATTERN:
-{pattern_text}
 
-{f'CONTEXT: {context}' if context else ''}
+def _build_image_blocks(image_data: Optional[str]) -> List[Dict[str, Any]]:
+    """Turn a JSON array of base64 image strings into Anthropic image blocks."""
+    if not image_data:
+        return []
+    try:
+        image_list = json.loads(image_data)
+    except json.JSONDecodeError as exc:
+        logger.warning("Failed to parse image_data JSON: %s", exc)
+        return []
 
-Provide detailed, beginner-friendly instructions."""
-
-        # Try each model in configured priority order
-        last_error = None
-        for model_name in self._model_priority_order:
-            try:
-                async with httpx.AsyncClient() as client:
-                    response = await client.post(
-                        "https://openrouter.ai/api/v1/chat/completions",
-                        headers={
-                            "Authorization": f"Bearer {self.openrouter_api_key}",
-                            "Content-Type": "application/json"
-                        },
-                        json={
-                            "model": model_name,
-                            "messages": [
-                                {"role": "system", "content": system_prompt},
-                                {"role": "user", "content": user_prompt}
-                            ]
-                        },
-                        timeout=30.0
-                    )
-                    response.raise_for_status()
-                    result = response.json()
-
-                    ai_response = result["choices"][0]["message"]["content"]
-
-                    # Track usage
-                    db = SessionLocal()
-                    try:
-                        input_chars = len(system_prompt) + len(user_prompt)
-                        output_chars = len(ai_response)
-                        self._increment_usage(db, model_name, input_chars, output_chars)
-                    finally:
-                        db.close()
-
-                    return f"[{model_name}] {ai_response}"
-
-            except Exception as e:
-                last_error = e
-                logger.warning("OpenRouter model %s failed: %s, trying next model...", model_name, e)
-                continue
-
-        # All models failed
-        return f"Error with OpenRouter (all models failed): {str(last_error)}"
-
-    async def _chat_with_openrouter(self, message: str, project_context: str, chat_history: str, image_data: Optional[str] = None) -> str:
-        """Use OpenRouter models for crochet/knitting chat with fallback (image support not yet implemented)"""
-        # TODO: Add image support for OpenRouter models that support it
-        if image_data:
-            logger.warning("Image data provided but OpenRouter image support not yet implemented")
-        # Use RAG to analyze user request and enhance context
-        user_analysis = rag_service.analyze_user_request(message)
-
-        system_prompt = """You are a friendly, expert crochet and knitting instructor and pattern designer. Help users with:
-- Crochet and knitting technique questions
-- Pattern interpretation and clarification
-- Troubleshooting common problems
-- Yarn, fiber, and hook/needle recommendations
-- Project planning and modifications
-- Stitch counting and pattern adjustments
-- Converting between crochet and knitting patterns when possible
-
-When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
-
-Always be encouraging and provide practical, actionable advice."""
-
-        # Enhance context with RAG if diagram is requested
-        context_info = ""
-        if project_context:
-            context_info += f"\nCURRENT PROJECT CONTEXT:\n{project_context}\n"
-        if chat_history:
-            context_info += f"\nPREVIOUS CONVERSATION:\n{chat_history}\n"
-
-        # Add RAG enhancement for diagram requests
-        if user_analysis['requests_diagram']:
-            pattern_text = message if any(pe in message.lower() for pe in ['round', 'row', 'chain', 'dc', 'sc']) else ""
-            if pattern_text:
-                rag_enhancement = rag_service.enhance_pattern_context(pattern_text, message)
-                context_info += f"\n{rag_enhancement}\n"
-
-        user_prompt = f"{context_info}\nUSER QUESTION: {message}"
-
-        # Try each model in configured priority order
-        last_error = None
-        for model_name in self._model_priority_order:
-            try:
-                async with httpx.AsyncClient() as client:
-                    response = await client.post(
-                        "https://openrouter.ai/api/v1/chat/completions",
-                        headers={
-                            "Authorization": f"Bearer {self.openrouter_api_key}",
-                            "Content-Type": "application/json"
-                        },
-                        json={
-                            "model": model_name,
-                            "messages": [
-                                {"role": "system", "content": system_prompt},
-                                {"role": "user", "content": user_prompt}
-                            ]
-                        },
-                        timeout=30.0
-                    )
-                    response.raise_for_status()
-                    result = response.json()
-
-                    ai_response = result["choices"][0]["message"]["content"]
-
-                    # Track usage
-                    db = SessionLocal()
-                    try:
-                        input_chars = len(system_prompt) + len(user_prompt)
-                        output_chars = len(ai_response)
-                        self._increment_usage(db, model_name, input_chars, output_chars)
-                    finally:
-                        db.close()
-
-                    return f"[{model_name}] {ai_response}"
-
-            except Exception as e:
-                last_error = e
-                logger.warning("OpenRouter model %s failed: %s, trying next model...", model_name, e)
-                continue
-
-        # All models failed
-        return f"Sorry, I'm having trouble responding right now: {str(last_error)}"
-
-    async def _translate_with_specific_openrouter_model(self, pattern_text: str, user_context: str, model_name: str) -> str:
-        """Translate pattern using a specific OpenRouter model"""
-        system_prompt = """You are an expert crochet and knitting pattern translator. Convert abbreviated crochet and knitting patterns into clear, readable instructions.
-
-Key responsibilities:
-- Expand all abbreviations (sc = single crochet, dc = double crochet, k = knit, p = purl, etc.)
-- Explain stitch placement and technique
-- Maintain the original pattern structure (rounds/rows)
-- Provide context for complex stitches
-- Be precise with stitch counts and placement"""
-
-        user_prompt = f"""Translate this crochet or knitting pattern into clear instructions:
-
-{pattern_text}
-
-{f'Additional context: {user_context}' if user_context else ''}
-
-Provide a clear, step-by-step translation."""
-
+    blocks: List[Dict[str, Any]] = []
+    for img_b64 in image_list:
         try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    "https://openrouter.ai/api/v1/chat/completions",
-                    headers={
-                        "Authorization": f"Bearer {self.openrouter_api_key}",
-                        "Content-Type": "application/json"
-                    },
-                    json={
-                        "model": model_name,
-                        "messages": [
-                            {"role": "system", "content": system_prompt},
-                            {"role": "user", "content": user_prompt}
-                        ]
-                    },
-                    timeout=60.0
-                )
-                response.raise_for_status()
-                result = response.json()
-                ai_response = result['choices'][0]['message']['content']
-
-                # Track usage
-                input_chars = len(system_prompt) + len(user_prompt)
-                output_chars = len(ai_response)
-                db = SessionLocal()
-                try:
-                    self._increment_usage(db, model_name, input_chars, output_chars)
-                finally:
-                    db.close()
-
-                return ai_response
-
-        except Exception as e:
-            error_msg = str(e)
-            if "503" in error_msg:
-                return f"The {model_name} model is currently unavailable. Please try a different model."
-            elif "429" in error_msg:
-                return f"Rate limit reached for {model_name}. Please try a different model or wait a few minutes."
-            else:
-                return f"Translation failed with {model_name}: {error_msg}"
-
-    async def _translate_with_specific_gemini_model(self, pattern_text: str, user_context: str, model_name: str) -> str:
-        """Translate pattern using a specific Gemini model"""
-        system_instruction = """You are an expert crochet and knitting pattern translator. Convert abbreviated crochet and knitting patterns into clear, readable instructions.
-
-Key responsibilities:
-- Expand all abbreviations (sc = single crochet, dc = double crochet, k = knit, p = purl, etc.)
-- Explain stitch placement and technique
-- Maintain the original pattern structure (rounds/rows)
-- Provide context for complex stitches
-- Be precise with stitch counts and placement"""
-
-        user_prompt = f"""Translate this crochet or knitting pattern into clear instructions:
-
-{pattern_text}
-
-{f'Additional context: {user_context}' if user_context else ''}
-
-Provide a clear, step-by-step translation."""
-
-        try:
-            client = self._get_client()
-            if not client:
-                return "Gemini client not configured"
-
-            response = client.models.generate_content(
-                model=model_name,
-                contents=user_prompt,
-                config={
-                    "system_instruction": system_instruction,
-                    "temperature": 0.3,
-                }
-            )
-
-            ai_response = response.text
-
-            # Track usage
-            input_chars = len(system_instruction) + len(user_prompt)
-            output_chars = len(ai_response)
-            db = SessionLocal()
-            try:
-                self._increment_usage(db, model_name, input_chars, output_chars)
-            finally:
-                db.close()
-
-            return ai_response
-
-        except Exception as e:
-            error_msg = str(e)
-            if "429" in error_msg or "quota" in error_msg.lower():
-                return f"Daily quota reached for {model_name}. Please try a different model or wait until tomorrow."
-            else:
-                return f"Translation failed with {model_name}: {error_msg}"
-
-    async def _chat_with_specific_openrouter_model(self, message: str, project_context: str, chat_history: str, model_name: str, image_data: Optional[str] = None) -> str:
-        """Chat using a specific OpenRouter model (image support not yet implemented)"""
-        # TODO: Add image support for OpenRouter models that support it
-        if image_data:
-            logger.warning("Image data provided but OpenRouter image support not yet implemented")
-        user_analysis = rag_service.analyze_user_request(message)
-
-        system_prompt = """You are a friendly, expert crochet and knitting instructor and pattern designer. Help users with:
-- Crochet and knitting technique questions
-- Pattern interpretation and clarification
-- Troubleshooting common problems
-- Yarn, fiber, and hook/needle recommendations
-- Project planning and modifications
-- Stitch counting and pattern adjustments
-- Converting between crochet and knitting patterns when possible
-
-When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
-
-Always be encouraging and provide practical, actionable advice."""
-
-        context_info = ""
-        if project_context:
-            context_info += f"\nCURRENT PROJECT CONTEXT:\n{project_context}\n"
-        if chat_history:
-            context_info += f"\nPREVIOUS CONVERSATION:\n{chat_history}\n"
-
-        if user_analysis['requests_diagram']:
-            pattern_text = message if any(pe in message.lower() for pe in ['round', 'row', 'chain', 'dc', 'sc']) else ""
-            if pattern_text:
-                rag_enhancement = rag_service.enhance_pattern_context(pattern_text, message)
-                context_info += f"\n{rag_enhancement}\n"
-
-        user_prompt = f"{context_info}\nUSER QUESTION: {message}"
-
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    "https://openrouter.ai/api/v1/chat/completions",
-                    headers={
-                        "Authorization": f"Bearer {self.openrouter_api_key}",
-                        "Content-Type": "application/json"
-                    },
-                    json={
-                        "model": model_name,
-                        "messages": [
-                            {"role": "system", "content": system_prompt},
-                            {"role": "user", "content": user_prompt}
-                        ]
-                    },
-                    timeout=60.0
-                )
-                response.raise_for_status()
-                result = response.json()
-                ai_response = result['choices'][0]['message']['content']
-
-                # Track usage
-                input_chars = len(system_prompt) + len(user_prompt)
-                output_chars = len(ai_response)
-                db = SessionLocal()
-                try:
-                    self._increment_usage(db, model_name, input_chars, output_chars)
-                finally:
-                    db.close()
-
-                return f"[{model_name}] {ai_response}"
-
-        except Exception as e:
-            error_msg = str(e)
-            if "503" in error_msg:
-                return f"The {model_name} model is currently unavailable (service overloaded). Please try a different model or use Smart Routing for automatic fallback."
-            elif "429" in error_msg:
-                return f"Rate limit reached for {model_name}. Please try a different model or wait a few minutes."
-            else:
-                return f"Sorry, model {model_name} failed: {error_msg}"
-
-    async def _chat_with_specific_gemini_model(self, message: str, project_context: str, chat_history: str, model_name: str, image_data: Optional[str] = None) -> str:
-        """Chat using a specific Gemini model with optional image support"""
-        user_analysis = rag_service.analyze_user_request(message)
-
-        # Enhanced system instruction for image analysis
-        if image_data:
-            system_instruction = """You are an expert crochet and knitting instructor and pattern designer. When analyzing images of crochet or knitting patterns, provide:
-
-1. **Pattern Name**: A descriptive name for the pattern shown
-2. **Pattern Notation**: The abbreviated notation (crochet: "ch 4, 12 dc in ring, sl st to join", knitting: "CO 40, k2, p2 rib for 1 inch")
-3. **Detailed Instructions**: Step-by-step instructions in plain English with clear paragraph breaks between rounds/rows
-4. **Difficulty Level**: beginner, intermediate, or advanced
-5. **Materials**: Yarn weight, hook/needle size, and other supplies needed
-6. **Estimated Time**: How long to complete (if determinable)
-7. **Special Notes**: Any unique techniques or tips
-
-Format your instructions with:
-- Clear paragraph breaks between each round/row
-- Numbered rounds/rows (e.g., "Round 1:", "Round 2:" or "Row 1:", "Row 2:")
-- Double line breaks between sections
-- Bullet points for materials lists
-
-Be thorough, accurate, and encouraging. Focus on making the pattern easy to follow."""
-        else:
-            system_instruction = """You are a friendly, expert crochet and knitting instructor and pattern designer. Help users with:
-- Crochet and knitting technique questions
-- Pattern interpretation and clarification
-- Troubleshooting common problems
-- Yarn, fiber, and hook/needle recommendations
-- Project planning and modifications
-- Stitch counting and pattern adjustments
-- Converting between crochet and knitting patterns when possible
-
-Format your responses with clear paragraph breaks for readability.
-
-When users ask for visual diagrams or charts, provide a detailed written description of the pattern. The system will automatically generate a visual SVG diagram alongside your response when pattern data is detected.
-
-Always be encouraging and provide practical, actionable advice."""
-
-        context_info = ""
-        if project_context:
-            context_info += f"\nCURRENT PROJECT CONTEXT:\n{project_context}\n"
-        if chat_history:
-            context_info += f"\nPREVIOUS CONVERSATION:\n{chat_history}\n"
-
-        if user_analysis['requests_diagram']:
-            pattern_text = message if any(pe in message.lower() for pe in ['round', 'row', 'chain', 'dc', 'sc']) else ""
-            if pattern_text:
-                rag_enhancement = rag_service.enhance_pattern_context(pattern_text, message)
-                context_info += f"\n{rag_enhancement}\n"
-
-        user_prompt = f"{context_info}\nUSER QUESTION: {message}"
-
-        try:
-            client = self._get_client()
-            if not client:
-                return "Gemini client not configured"
-
-            # Build contents array with text and images if provided
-            if image_data:
-                try:
-                    image_list = json.loads(image_data)
-                    # Create parts list with text and images
-                    parts = [user_prompt]
-                    for img_base64 in image_list:
-                        # Gemini SDK expects Part objects with inline_data
-                        img_bytes = base64.b64decode(img_base64)
-
-                        # Detect MIME type from magic bytes
-                        mime_type = self._detect_mime_type(img_bytes)
-
-                        parts.append(types.Part.from_bytes(
-                            data=img_bytes,
-                            mime_type=mime_type
-                        ))
-                    contents = parts
-                except (json.JSONDecodeError, base64.binascii.Error) as e:
-                    logger.warning("Failed to parse image data: %s", e)
-                    contents = user_prompt
-            else:
-                contents = user_prompt
-
-            response = client.models.generate_content(
-                model=model_name,
-                contents=contents,
-                config={
-                    "system_instruction": system_instruction,
-                    "temperature": 0.7,
-                }
-            )
-
-            ai_response = response.text
-
-            # Track usage
-            input_chars = len(system_instruction) + len(user_prompt)
-            output_chars = len(ai_response)
-            db = SessionLocal()
-            try:
-                self._increment_usage(db, model_name, input_chars, output_chars)
-            finally:
-                db.close()
-
-            return f"[{model_name}] {ai_response}"
-
-        except Exception as e:
-            error_msg = str(e)
-            if "429" in error_msg or "quota" in error_msg.lower():
-                return f"Daily quota reached for {model_name}. Please try a different model or wait until tomorrow."
-            else:
-                return f"Sorry, model {model_name} failed: {error_msg}"
-
-    def _fallback_translation(self, pattern_text: str) -> str:
-        """Basic pattern translation without AI"""
-        # Simple abbreviation expansion as fallback
-        abbreviations = {
-            'sc': 'single crochet',
-            'dc': 'double crochet',
-            'hdc': 'half double crochet',
-            'tc': 'treble crochet',
-            'sl st': 'slip stitch',
-            'ch': 'chain',
-            'st': 'stitch',
-            'sts': 'stitches',
-            'inc': 'increase',
-            'dec': 'decrease',
-            'yo': 'yarn over',
-            'sk': 'skip',
-            'rep': 'repeat',
-            'rnd': 'round',
-            'beg': 'beginning',
-            'sp': 'space',
-            'tog': 'together'
-        }
-
-        translated = pattern_text
-        for abbrev, full_form in abbreviations.items():
-            translated = translated.replace(abbrev, full_form)
-
-        return f"Basic translation (AI not available):\n\n{translated}\n\nNote: This is a simple translation. For detailed instructions, please configure AI service."
-
-    def get_ai_provider_config(self) -> Dict[str, Any]:
-        """Get current AI provider configuration"""
-        return {
-            "use_openrouter": self.use_openrouter_default,
-            "current_provider": self._ai_provider_preference,
-            "selected_model": self._selected_model,
-            "available_models": list(self.ALL_AVAILABLE_MODELS.keys()),
-            "model_priority_order": self._model_priority_order
-        }
-
-    def set_ai_model(self, model_name: Optional[str] = None, priority_order: Optional[list] = None) -> Dict[str, Any]:
-        """
-        Set AI model configuration
-        Three modes:
-        1. Single Model: model_name is set
-        2. Smart Routing: model_name=None, priority_order=None (complexity-based selection)
-        3. Fallback Chain: model_name=None, priority_order=[...] (try in order until success)
-
-        Args:
-            model_name: Specific model to use, or None for smart/fallback routing
-            priority_order: Custom priority order for fallback chain, or None for smart routing
-        """
-        # Validate model if specified
-        if model_name and model_name not in self.ALL_AVAILABLE_MODELS:
-            return {
-                "success": False,
-                "message": f"Invalid model: {model_name}. Available models: {list(self.ALL_AVAILABLE_MODELS.keys())}"
+            img_bytes = base64.b64decode(img_b64)
+        except (base64.binascii.Error, ValueError) as exc:
+            logger.warning("Failed to decode base64 image: %s", exc)
+            continue
+        blocks.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": _detect_mime_type(img_bytes),
+                    "data": img_b64,
+                },
             }
+        )
+    return blocks
 
-        # Set model selection
-        self._selected_model = model_name
 
-        # Handle three distinct modes
-        if model_name:
-            # Mode 1: Single Model
-            model_info = self.ALL_AVAILABLE_MODELS[model_name]
-            if model_info["provider"] == "openrouter":
-                self._ai_provider_preference = "openrouter"
-                self.use_openrouter_default = True
-            elif model_info["provider"] == "gemini":
-                self._ai_provider_preference = "gemini"
-                self.use_openrouter_default = False
-            mode_description = f"Single Model: {model_name}"
-        elif priority_order:
-            # Mode 3: Fallback Chain
-            # Validate priority order
-            for model in priority_order:
-                if model not in self.ALL_AVAILABLE_MODELS:
-                    return {
-                        "success": False,
-                        "message": f"Invalid model in priority order: {model}"
-                    }
-            self._model_priority_order = priority_order
-            self._ai_provider_preference = "auto"
-            mode_description = f"Fallback Chain ({len(priority_order)} models)"
-        else:
-            # Mode 2: Smart Routing (complexity-based)
-            self._model_priority_order = []  # Clear priority order for smart routing
-            self._ai_provider_preference = "auto"
-            mode_description = "Smart Routing (Complexity-Based)"
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
 
-        # Persist configuration to database
-        self._save_config_to_db()
+class AIService:
+    """Thin wrapper around the Anthropic SDK pointed at z.ai.
+
+    Retains the old public surface that GraphQL resolvers depend on, but the
+    AI work is now a single code path.
+    """
+
+    def __init__(self) -> None:
+        self._client: Optional[Anthropic] = None
+        self._default_model = DEFAULT_MODEL
+
+    # -- client ----------------------------------------------------------------
+
+    def _get_client(self) -> Optional[Anthropic]:
+        """Lazy-initialize the Anthropic client."""
+        if self._client is not None:
+            return self._client
+        api_key = settings.zai_api_key
+        if not api_key:
+            logger.error("ZAI_API_KEY is not configured; AI calls will fail.")
+            return None
+        self._client = Anthropic(api_key=api_key, base_url=ZAI_BASE_URL)
+        return self._client
+
+    # -- public: translation ---------------------------------------------------
+
+    async def translate_crochet_pattern(
+        self, pattern_text: str, user_context: str = ""
+    ) -> str:
+        """Translate crochet/knitting notation into readable instructions."""
+        client = self._get_client()
+        if client is None:
+            return _fallback_translation(pattern_text)
+
+        user_prompt = (
+            "Please translate this crochet or knitting pattern into clear, "
+            "step-by-step instructions:\n\n"
+            f"PATTERN:\n{pattern_text}\n\n"
+            f"{f'CONTEXT: {user_context}' if user_context else ''}\n\n"
+            "Provide detailed, beginner-friendly instructions."
+        )
+
+        try:
+            response = client.messages.create(
+                model=self._default_model,
+                max_tokens=MAX_TOKENS_TRANSLATE,
+                system=TRANSLATE_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+            return _extract_text(response)
+        except Exception as exc:  # noqa: BLE001 — surface error to UI
+            logger.exception("z.ai translate call failed")
+            return f"Error translating pattern: {exc}"
+
+    # -- public: chat ----------------------------------------------------------
+
+    async def chat_about_pattern(
+        self,
+        message: str,
+        project_context: str = "",
+        chat_history: str = "",
+        image_data: Optional[str] = None,
+    ) -> str:
+        """Chat with AI about crochet/knitting patterns and techniques.
+
+        Supports image analysis when `image_data` is a JSON array of base64
+        strings.
+        """
+        client = self._get_client()
+        if client is None:
+            return "AI service not configured. Please set ZAI_API_KEY."
+
+        user_analysis = rag_service.analyze_user_request(message)
+
+        # Switch to the image-tuned system prompt when we're analyzing images.
+        system_prompt = IMAGE_CHAT_SYSTEM_PROMPT if image_data else CHAT_SYSTEM_PROMPT
+
+        context_info = ""
+        if project_context:
+            context_info += f"\nCURRENT PROJECT CONTEXT:\n{project_context}\n"
+        if chat_history:
+            context_info += f"\nPREVIOUS CONVERSATION:\n{chat_history}\n"
+
+        # RAG enhancement for diagram requests (unchanged from old behavior).
+        if user_analysis.get("requests_diagram"):
+            pattern_text = (
+                message
+                if any(pe in message.lower() for pe in ["round", "row", "chain", "dc", "sc"])
+                else ""
+            )
+            if pattern_text:
+                rag_enhancement = rag_service.enhance_pattern_context(
+                    pattern_text, message
+                )
+                context_info += f"\n{rag_enhancement}\n"
+
+        user_prompt = f"{context_info}\nUSER QUESTION: {message}"
+
+        # Build content blocks: one text block plus any image blocks.
+        content: List[Dict[str, Any]] = _build_image_blocks(image_data)
+        content.append({"type": "text", "text": user_prompt})
+
+        try:
+            response = client.messages.create(
+                model=self._default_model,
+                max_tokens=MAX_TOKENS_CHAT,
+                system=system_prompt,
+                messages=[{"role": "user", "content": content}],
+            )
+            return _extract_text(response)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("z.ai chat call failed")
+            return f"Sorry, I'm having trouble responding right now: {exc}"
+
+    # -- public: GraphQL compatibility stubs -----------------------------------
+    # These are called from queries.py / mutations.py. The cascade/quota
+    # machinery is gone, but the GraphQL shape is preserved so the frontend
+    # keeps working until Phase 3 housekeeping tears out the UI.
+
+    def get_usage_stats(self) -> Dict[str, Dict[str, Any]]:
+        """Return a single-model usage stat block.
+
+        z.ai does not expose per-request quota headers through this endpoint,
+        so we report effectively-unlimited and zero usage. The dashboard UI
+        still renders cleanly.
+        """
+        return {
+            self._default_model: {
+                "current_usage": 0,
+                "daily_limit": 999_999,
+                "remaining": 999_999,
+                "percentage_used": 0,
+                "priority": 1,
+                "use_case": "z.ai (GLM-4.7)",
+                "total_input_characters": 0,
+                "total_output_characters": 0,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+            }
+        }
+
+    def reset_daily_usage(self) -> Dict[str, Any]:
+        """No-op: z.ai manages its own quotas."""
+        from datetime import date
 
         return {
             "success": True,
-            "message": f"AI model configuration updated. Mode: {mode_description}",
-            "use_openrouter": self.use_openrouter_default,
-            "current_provider": self._ai_provider_preference,
-            "selected_model": self._selected_model,
-            "model_priority_order": self._model_priority_order
+            "message": "Usage tracking is managed by z.ai; nothing to reset.",
+            "reset_date": date.today().isoformat(),
         }
 
-# Global instance
+    def get_ai_provider_config(self) -> Dict[str, Any]:
+        """Return a single-model config payload."""
+        return {
+            "use_openrouter": False,
+            "current_provider": "zai",
+            "selected_model": self._default_model,
+            "available_models": [self._default_model],
+            "model_priority_order": [],
+        }
+
+    def set_ai_model(
+        self,
+        model_name: Optional[str] = None,
+        priority_order: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """No-op: model is fixed to the z.ai default.
+
+        Returns success with the single available model so frontend UX that
+        POSTs updates does not error. Silently ignores input.
+        """
+        return {
+            "success": True,
+            "message": (
+                "Model selection is disabled; z.ai routes all requests "
+                f"through {self._default_model}."
+            ),
+            "use_openrouter": False,
+            "current_provider": "zai",
+            "selected_model": self._default_model,
+            "model_priority_order": [],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+def _extract_text(response: Any) -> str:
+    """Pull the text out of an Anthropic Messages response.
+
+    Anthropic responses come back as a list of content blocks. We return the
+    concatenation of all text blocks (usually just one).
+    """
+    parts: List[str] = []
+    for block in getattr(response, "content", []) or []:
+        # SDK returns objects with .type/.text; fall back to dict access for
+        # anything returned by test fakes.
+        block_type = getattr(block, "type", None) or (
+            block.get("type") if isinstance(block, dict) else None
+        )
+        if block_type == "text":
+            text = getattr(block, "text", None) or (
+                block.get("text") if isinstance(block, dict) else None
+            )
+            if text:
+                parts.append(text)
+    return "".join(parts)
+
+
+def _fallback_translation(pattern_text: str) -> str:
+    """Basic abbreviation expansion used when ZAI_API_KEY is missing."""
+    abbreviations = {
+        "sc": "single crochet",
+        "dc": "double crochet",
+        "hdc": "half double crochet",
+        "tc": "treble crochet",
+        "sl st": "slip stitch",
+        "ch": "chain",
+        "st": "stitch",
+        "sts": "stitches",
+        "inc": "increase",
+        "dec": "decrease",
+        "yo": "yarn over",
+        "sk": "skip",
+        "rep": "repeat",
+        "rnd": "round",
+        "beg": "beginning",
+        "sp": "space",
+        "tog": "together",
+    }
+    translated = pattern_text
+    for abbrev, full_form in abbreviations.items():
+        translated = translated.replace(abbrev, full_form)
+    return (
+        "Basic translation (AI not available):\n\n"
+        f"{translated}\n\n"
+        "Note: This is a simple translation. For detailed instructions, "
+        "please configure ZAI_API_KEY."
+    )
+
+
+# Global instance (maintained so existing imports keep working).
 ai_service = AIService()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,8 @@ pydantic==2.5.0
 pydantic-settings==2.1.0
 
 # AI Integration
-google-genai==0.8.0
+# z.ai exposes an Anthropic-compatible proxy; we use the official SDK.
+anthropic>=0.40.0,<1.0.0
 httpx==0.25.2
 
 # Diagram Generation

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -56,15 +56,11 @@ class TestTranslate:
         )
 
     @pytest.mark.asyncio
-    async def test_falls_back_when_no_api_key(self, monkeypatch):
+    async def test_returns_config_error_when_no_api_key(self, monkeypatch):
         svc = AIService()
         monkeypatch.setattr(svc, "_get_client", lambda: None)
-        # Use a pattern that avoids the known `ch` -> `chain` substring collision.
         result = await svc.translate_crochet_pattern("yo, sl st to close")
-        assert "Basic translation" in result
-        assert "yarn over" in result
-        assert "slip stitch" in result
-        # And make sure it tells the user what to configure
+        assert "not configured" in result
         assert "ZAI_API_KEY" in result
 
 

--- a/backend/tests/test_ai_service.py
+++ b/backend/tests/test_ai_service.py
@@ -1,0 +1,209 @@
+"""
+Tests for the collapsed AI service.
+
+Covers:
+- Unit tests with a mocked Anthropic client (no network, always run)
+- Opt-in integration tests against the real z.ai endpoint, gated on
+  ZAI_API_KEY being set in the environment
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services import ai_service as ai_service_module
+from app.services.ai_service import AIService
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (mocked client)
+# ---------------------------------------------------------------------------
+
+def _make_fake_response(text: str) -> SimpleNamespace:
+    """Build a minimal object that looks like an Anthropic Messages response."""
+    block = SimpleNamespace(type="text", text=text)
+    return SimpleNamespace(content=[block])
+
+
+@pytest.fixture
+def svc_with_fake_client(monkeypatch):
+    """Return an AIService whose _get_client returns a MagicMock."""
+    svc = AIService()
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _make_fake_response("mock output")
+    monkeypatch.setattr(svc, "_get_client", lambda: fake_client)
+    return svc, fake_client
+
+
+class TestTranslate:
+    @pytest.mark.asyncio
+    async def test_returns_text_from_anthropic_response(self, svc_with_fake_client):
+        svc, _ = svc_with_fake_client
+        result = await svc.translate_crochet_pattern("ch 4, sc in 2nd ch from hook")
+        assert result == "mock output"
+
+    @pytest.mark.asyncio
+    async def test_uses_default_sonnet_model(self, svc_with_fake_client):
+        svc, fake_client = svc_with_fake_client
+        await svc.translate_crochet_pattern("ch 4")
+        call_kwargs = fake_client.messages.create.call_args.kwargs
+        assert call_kwargs["model"] == "claude-sonnet-4-5-20250929"
+        assert call_kwargs["system"].startswith(
+            "You are an expert crochet and knitting instructor"
+        )
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_no_api_key(self, monkeypatch):
+        svc = AIService()
+        monkeypatch.setattr(svc, "_get_client", lambda: None)
+        # Use a pattern that avoids the known `ch` -> `chain` substring collision.
+        result = await svc.translate_crochet_pattern("yo, sl st to close")
+        assert "Basic translation" in result
+        assert "yarn over" in result
+        assert "slip stitch" in result
+        # And make sure it tells the user what to configure
+        assert "ZAI_API_KEY" in result
+
+
+class TestChat:
+    @pytest.mark.asyncio
+    async def test_returns_text_from_anthropic_response(self, svc_with_fake_client):
+        svc, _ = svc_with_fake_client
+        result = await svc.chat_about_pattern("What does sc2tog mean?")
+        assert result == "mock output"
+
+    @pytest.mark.asyncio
+    async def test_includes_chat_history_and_context(self, svc_with_fake_client):
+        svc, fake_client = svc_with_fake_client
+        await svc.chat_about_pattern(
+            message="What's next?",
+            project_context="granny square blanket",
+            chat_history="User: how do I start?\nAI: make a magic ring",
+        )
+        call_kwargs = fake_client.messages.create.call_args.kwargs
+        content = call_kwargs["messages"][0]["content"]
+        # content should be a list with a final text block holding prompt
+        text_block = next(c for c in content if c["type"] == "text")
+        assert "granny square blanket" in text_block["text"]
+        assert "magic ring" in text_block["text"]
+        assert "What's next?" in text_block["text"]
+
+    @pytest.mark.asyncio
+    async def test_reports_missing_api_key(self, monkeypatch):
+        svc = AIService()
+        monkeypatch.setattr(svc, "_get_client", lambda: None)
+        result = await svc.chat_about_pattern("hi")
+        assert "ZAI_API_KEY" in result
+
+    @pytest.mark.asyncio
+    async def test_image_data_produces_image_block(self, svc_with_fake_client):
+        """Image data should be decoded into an Anthropic image content block."""
+        svc, fake_client = svc_with_fake_client
+        # 1x1 PNG (base64 of a minimal valid PNG)
+        png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB"
+            "0C8AAAAASUVORK5CYII="
+        )
+        import json
+
+        await svc.chat_about_pattern(
+            message="what is this?",
+            image_data=json.dumps([png_b64]),
+        )
+        content = fake_client.messages.create.call_args.kwargs["messages"][0][
+            "content"
+        ]
+        image_blocks = [c for c in content if c["type"] == "image"]
+        assert len(image_blocks) == 1
+        assert image_blocks[0]["source"]["media_type"] == "image/png"
+
+
+class TestCompatShims:
+    """The GraphQL surface expects usage/config/reset methods to keep working."""
+
+    def test_usage_stats_has_default_model(self):
+        svc = AIService()
+        stats = svc.get_usage_stats()
+        assert "claude-sonnet-4-5-20250929" in stats
+
+    def test_provider_config_reports_zai(self):
+        svc = AIService()
+        config = svc.get_ai_provider_config()
+        assert config["current_provider"] == "zai"
+        assert config["selected_model"] == "claude-sonnet-4-5-20250929"
+
+    def test_set_ai_model_is_noop_but_successful(self):
+        svc = AIService()
+        result = svc.set_ai_model(model_name="some-other-model")
+        assert result["success"] is True
+        # Model selection is disabled; we always report the default
+        assert result["selected_model"] == "claude-sonnet-4-5-20250929"
+
+    def test_reset_daily_usage_succeeds(self):
+        svc = AIService()
+        result = svc.reset_daily_usage()
+        assert result["success"] is True
+
+
+class TestExtractText:
+    def test_concatenates_text_blocks(self):
+        resp = SimpleNamespace(
+            content=[
+                SimpleNamespace(type="text", text="Hello "),
+                SimpleNamespace(type="text", text="world"),
+            ]
+        )
+        assert ai_service_module._extract_text(resp) == "Hello world"
+
+    def test_ignores_non_text_blocks(self):
+        resp = SimpleNamespace(
+            content=[
+                SimpleNamespace(type="tool_use", text=None),
+                SimpleNamespace(type="text", text="keep me"),
+            ]
+        )
+        assert ai_service_module._extract_text(resp) == "keep me"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (real z.ai endpoint) — opt-in via ZAI_API_KEY
+# ---------------------------------------------------------------------------
+
+pytestmark_integration = pytest.mark.skipif(
+    not os.getenv("ZAI_API_KEY"),
+    reason="ZAI_API_KEY not set; skipping integration tests against z.ai",
+)
+
+
+@pytestmark_integration
+@pytest.mark.asyncio
+async def test_live_translate_crochet_pattern():
+    """Smoke-test against the real z.ai endpoint."""
+    svc = AIService()
+    result = await svc.translate_crochet_pattern(
+        "Round 1: Ch 4, sl st to join to form ring. Ch 3, 11 dc in ring, sl st to top of ch-3. (12 dc)",
+        user_context="beginner",
+    )
+    # Sanity: response should be a non-trivial string referring to crochet terms
+    assert isinstance(result, str)
+    assert len(result) > 100
+    # Should expand abbreviations or describe stitches somehow
+    assert any(
+        term in result.lower()
+        for term in ("double crochet", "chain", "slip stitch", "round")
+    )
+
+
+@pytestmark_integration
+@pytest.mark.asyncio
+async def test_live_chat_about_pattern():
+    svc = AIService()
+    result = await svc.chat_about_pattern(
+        message="What does sc2tog mean in crochet?",
+    )
+    assert isinstance(result, str)
+    assert len(result) > 50
+    assert "single crochet" in result.lower() or "decrease" in result.lower()


### PR DESCRIPTION
## Summary
- Collapses 932-line provider cascade (8 Gemini/OpenRouter methods) to a single Anthropic SDK client pointed at z.ai (GLM-4.7 behind the scenes)
- `ai_service.py`: 1104 -> 409 lines
- Drops quota tracking, fallback chains, and model-selection heuristics — z.ai handles routing internally
- Default model: `claude-sonnet-4-5-20250929` -> z.ai routes to GLM-4.7 (high quality tier)
- Existing GraphQL mutation surface unchanged (frontend requires no changes) — `setAiModel` / `aiUsageDashboard` / `aiProviderConfig` / `resetDailyUsage` all still respond, but return single-model / zero-usage payloads. Phase 3 housekeeping can remove the UI.

## Env changes
- Remove: `GEMINI_API_KEY`, `OPENROUTER_API_KEY`
- Add: `ZAI_API_KEY`
- Vercel + OCI both need the new key before deploy

## DB
- `ai_model_usage` and `ai_model_config` tables and ORM models are left in place (stubs don't read/write them). No migration required. Tear-down is a future housekeeping task.

## Test plan
- [x] Existing unit tests pass (55 passed, 2 skipped — the 2 skipped are the live z.ai integration tests gated on `ZAI_API_KEY`)
- [x] New unit tests for `AIService` (13 tests) pass — mocked Anthropic client, cover translate / chat / image blocks / compat shims / text extraction
- [x] Live integration tests pass against real z.ai endpoint when `ZAI_API_KEY` is set (`test_live_translate_crochet_pattern`, `test_live_chat_about_pattern`)
- [x] Manual smoke: translated a 3-round coaster pattern locally — 4.6KB response with numbered steps, abbreviation expansion, stitch-count checks, and tips. Output quality at parity or better vs. previous Gemini output.
- [ ] Vercel preview + OCI backend deploy cleanly (post-merge, not on this PR)

## Revert plan
`main` retains the pre-migration code; revert the merge commit if z.ai goes down. Do NOT ship a dual-provider fallback by default — monitor for a week.